### PR TITLE
adding basic CI setup for travis, sans credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+  - "6"
+
+before_script:
+  - "npm install -g gulp"
+
+script:
+  - "npm install"
+  - "gulp"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ before_script:
 
 script:
   - "npm install"
-  - "gulp"
+  - "gulp lint"
 
 deploy:
   provider: script
-  script: "scripts/deploy.sh"
+  script: "gulp commit"
   on:
     branch: "stable"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,9 @@ before_script:
 script:
   - "npm install"
   - "gulp"
+
+deploy:
+  provider: script
+  script: "scripts/deploy.sh"
+  on:
+    branch: "stable"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,3 @@
+#! /usr/bin/bash
+
+echo "curl https://screeps.com/api/user/code POST dist/bundle.js"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,3 +1,0 @@
-#! /usr/bin/bash
-
-echo "curl https://screeps.com/api/user/code POST dist/bundle.js"


### PR DESCRIPTION
This will kick off a build (the lint task) every time somebody commits and deploy (commit code to the server) when changes are made on `stable`. The [build is red](https://travis-ci.org/ssube/screeps-ai/builds/140566752) since the credentials file is missing. You should add that and encrypt it: https://docs.travis-ci.com/user/encrypting-files/
